### PR TITLE
Added Surfrad unmetered locations

### DIFF
--- a/solcast/unmetered_locations.py
+++ b/solcast/unmetered_locations.py
@@ -29,6 +29,16 @@ UNMETERED_LOCATIONS = {
         "longitude": 78.042142,
         "resource_id": "b926-8fd2-ad3f-e4f5",
     },
+    "Fort Peck": {
+        "latitude": 48.30783,
+        "longitude": -105.1017,
+        "resource_id": "3ae7-2456-492c-9aba",
+    },
+    "Goodwin Creek": {
+        "latitude": 34.2547,
+        "longitude": -89.8729,
+        "resource_id": "b787-cf17-e429-ef1d",
+    },
 }
 
 


### PR DESCRIPTION
Added the [Fort Peck, Montana](https://gml.noaa.gov/grad/surfrad/ftpeck.html) and [Goodwin Creek, Mississippi](https://gml.noaa.gov/grad/surfrad/goodwin.html) Surfrad sites as [Unmetered Locations](https://docs.solcast.com.au/#unmetered-locations).