### PR TITLE
hotfix: point to macos-14 runner instead of latest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: ['ubuntu-latest', 'macos-14', 'windows-latest']
+        os: ['ubuntu-latest', 'macos-13', 'windows-latest']
         python-version: ["3.7", "3.11"]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+        os: ['ubuntu-latest', 'macos-14', 'windows-latest']
         python-version: ["3.7", "3.11"]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
the `macos-latest` runner doesn't have python versions <3.10. Using `macos-13` should fix [example](https://github.com/python-pillow/Pillow/pull/8010),

[Issue](https://github.com/actions/setup-python/issues/856)