### PR TITLE
Bump package version to 1.5.0

### DIFF
--- a/solcast/__init__.py
+++ b/solcast/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.4.0"
+__version__ = "1.5.0"
 
 from . import (
     aggregations,


### PR DESCRIPTION
## Summary

- Set the package version to `1.5.0` so the source metadata matches the existing `v1.5.0` release tag and premium forecast contents.

## Validation

- `uv build --sdist --wheel`
- Verified wheel and source distribution metadata both report `Version: 1.5.0`

After merge, the existing `v1.5.0` tag should be moved to the merge commit and pushed to trigger the corrected PyPI upload.