### PR TITLE
Prepare correct 1.5.0 release

### DIFF
--- a/solcast/__init__.py
+++ b/solcast/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.4.0"
+__version__ = "1.5.0"
 
 from . import (
     aggregations,

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -42,6 +42,22 @@ def test_advanced_pv_power():
     assert res.success is True
 
 
+def test_premium_pv_power():
+    res = forecast.premium_pv_power(
+        resource_id="cbf6-a872-1cb2-566f",
+        hours=3,
+    )
+    assert res.success is True
+
+
+def test_premium_wind_power():
+    res = forecast.premium_wind_power(
+        resource_id="c533-fbce-05b5-b3ef",
+        hours=3,
+    )
+    assert res.success is True
+
+
 def test_soiling_kimber():
     lats, longs = load_test_locations_coordinates()
     res = forecast.soiling_kimber(


### PR DESCRIPTION
## Summary

- Set the package version to `1.5.0` to match the existing premium forecast release contents.
- Add integration coverage for the premium PV and premium wind forecast endpoints.

## Validation

- `uv run --group test pytest tests/test_forecast.py`
- 7 tests passed
- `uv build --sdist --wheel`
- Wheel and source distribution metadata both report `Version: 1.5.0`

After merge, move the existing `v1.5.0` tag to the merge commit to trigger the corrected PyPI upload.